### PR TITLE
add demonstration firewall rules reading unikernel for QubesOS

### DIFF
--- a/fw-rules-reader/config.ml
+++ b/fw-rules-reader/config.ml
@@ -1,0 +1,9 @@
+open Mirage
+
+let main =
+  foreign
+    ~packages:[ package "mirage-qubes" ]
+    "Unikernel.Main" (time @-> job)
+
+let () =
+  register "fw-rules-reader" [main $ default_time]

--- a/fw-rules-reader/unikernel.ml
+++ b/fw-rules-reader/unikernel.ml
@@ -1,0 +1,18 @@
+open Lwt.Infix
+
+let src = Logs.Src.create "firewall_reader" ~doc:"FW reader"
+module Log = (val Logs.src_log src : Logs.LOG)
+
+module Main(Time : Mirage_time_lwt.S) = struct
+
+  let start t =
+    Qubes.DB.connect ~domid:0 () >>= fun qubesDB ->
+    let bindings = Qubes.DB.bindings qubesDB in
+    let rec print_and_loop bindings =
+      Qubes.DB.KeyMap.iter (fun k v -> Logs.info (fun m -> m "%s %s" k v)) bindings;
+      Qubes.DB.after qubesDB bindings >>= print_and_loop
+    in
+    print_and_loop bindings
+    (* Time.sleep_ns 1_000_000L >>= fun () -> *)
+
+end


### PR DESCRIPTION
Simple demonstration to read rule updates from QubesDB. 
Is this the right place? Collaboration with @yomimono :palm_tree: 