### PR TITLE
adapt to new let's encrypt API, requires a changed dns-certify

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,7 +16,6 @@ ifeq ($(MODE),unix)
 UNIKERNELS += secondary-git
 endif
 
-MIRAGE_FLAGS += --prng fortuna
 MODE ?= "unix"
 
 BUILD  = $(patsubst %, %-build, $(UNIKERNELS))

--- a/certificate/config.ml
+++ b/certificate/config.ml
@@ -30,13 +30,9 @@ let key_seed =
   let doc = Key.Arg.info ~doc:"private key seed" ["key-seed"] in
   Key.(create "key-seed" Arg.(opt (some string) None doc))
 
-let production =
-  let doc = Key.Arg.info ~doc:"Use the production let's encrypt servers" ["production"] in
-  Key.(create "production" Arg.(flag doc))
-
 let keys = Key.[
     abstract port ; abstract dns_key ; abstract dns_server ; abstract dns_port ;
-    abstract hostname ; abstract additional ; abstract key_seed ; abstract production
+    abstract hostname ; abstract additional ; abstract key_seed
   ]
 
 let packages =
@@ -46,11 +42,11 @@ let packages =
     package "randomconv" ;
     package "logs" ;
     package ~sublibs:[ "mirage" ] "dns-certify";
-    package ~sublibs:[ "mirage" ] "tls" ;
+    package "tls-mirage" ;
   ]
 
 let main =
-  foreign ~keys ~packages ~deps:[abstract nocrypto] "Unikernel.Main"
+  foreign ~keys ~packages "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)
 
 let () =

--- a/certificate/unikernel.ml
+++ b/certificate/unikernel.ml
@@ -53,14 +53,13 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
     Logs.app (fun m -> m "certificate chain:@.%s" certs);
     Logs.app (fun m -> m "private key:@.%s" key)
 
-  let start _random _pclock _mclock _ stack _ =
+  let start _random _pclock _mclock _ stack =
     let hostname = Domain_name.(host_exn (of_string_exn (Key_gen.hostname ()))) in
     let additional_hostnames =
       List.map (fun n -> Domain_name.(host_exn (of_string_exn n)))
         (Astring.String.cuts ~empty:false ~sep:"," (Key_gen.additional ()))
     in
-    let ca = if Key_gen.production () then `Production else `Staging in
-    D.retrieve_certificate ~ca stack ~dns_key:(Key_gen.dns_key ())
+    D.retrieve_certificate stack ~dns_key:(Key_gen.dns_key ())
       ~hostname ~additional_hostnames ?key_seed:(Key_gen.key_seed ())
       (Key_gen.dns_server ()) (Key_gen.dns_port ()) >>= function
     | Error (`Msg msg) ->

--- a/client/config.ml
+++ b/client/config.ml
@@ -15,7 +15,6 @@ let dns_handler =
   in
   foreign
     ~keys:[Key.abstract hostname]
-    ~deps:[abstract nocrypto]
     ~packages
     "Unikernel.Main" (random @-> mclock @-> stackv4 @-> job)
 

--- a/client/unikernel.ml
+++ b/client/unikernel.ml
@@ -6,7 +6,7 @@ module Main (R : Mirage_random.S) (M : Mirage_clock.MCLOCK) (S : Mirage_stack.V4
 
   module DNS = Dns_client_mirage.Make(R)(M)(S)
 
-  let start _ _ s _ =
+  let start _ _ s =
     let t = DNS.create s in
     let host = Domain_name.(host_exn (of_string_exn (Key_gen.hostname ()))) in
     DNS.gethostbyname t host >|= function

--- a/lets-encrypt/config.ml
+++ b/lets-encrypt/config.ml
@@ -39,7 +39,7 @@ let packages =
     package "duration" ;
     package "logs" ;
     package "cohttp-mirage" ;
-    package ~min:"0.2.0" "letsencrypt" ;
+    package ~min:"0.2.1" "letsencrypt" ;
     package "conduit-mirage" ;
     package "dns-tsig";
     package "dns-certify";
@@ -49,7 +49,7 @@ let packages =
 ]
 
 let client =
-  foreign ~deps:[abstract nocrypto] ~keys ~packages "Unikernel.Client" @@
+  foreign ~keys ~packages "Unikernel.Client" @@
   random @-> pclock @-> mclock @-> time @-> stackv4 @-> resolver @-> conduit @-> job
 
 let () =

--- a/lets-encrypt/config.ml
+++ b/lets-encrypt/config.ml
@@ -39,9 +39,10 @@ let packages =
     package "duration" ;
     package "logs" ;
     package "cohttp-mirage" ;
-    package "letsencrypt" ;
+    package ~min:"0.2.0" "letsencrypt" ;
     package "conduit-mirage" ;
     package "dns-tsig";
+    package "dns-certify";
     package ~min:"4.3.0" ~sublibs:[ "mirage" ] "dns-server";
     package "randomconv" ;
     package ~min:"0.3.0" "domain-name"

--- a/lets-encrypt/config.ml
+++ b/lets-encrypt/config.ml
@@ -42,8 +42,8 @@ let packages =
     package ~min:"0.2.1" "letsencrypt" ;
     package "conduit-mirage" ;
     package "dns-tsig";
-    package "dns-certify";
-    package ~min:"4.3.0" ~sublibs:[ "mirage" ] "dns-server";
+    package ~min:"4.4.0" "dns-certify";
+    package ~min:"4.4.0" ~sublibs:[ "mirage" ] "dns-server";
     package "randomconv" ;
     package ~min:"0.3.0" "domain-name"
 ]

--- a/lets-encrypt/unikernel.ml
+++ b/lets-encrypt/unikernel.ml
@@ -111,7 +111,7 @@ module Client (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.
                      Domain_name.pp name);
         None
 
-  let start _random _pclock _mclock _ stack res ctx _ =
+  let start _random _pclock _mclock _ stack res ctx =
     let keyname, keyzone, dnskey =
       match Dnskey.name_key_of_string (Key_gen.dns_key ()) with
       | Error (`Msg msg) -> Logs.err (fun m -> m "couldn't parse dnskey: %s" msg) ; exit 64

--- a/primary-git/config.ml
+++ b/primary-git/config.ml
@@ -15,13 +15,11 @@ let dns_handler =
     package "logs" ;
     package ~min:"4.3.0" ~sublibs:["mirage"; "zone"] "dns-server";
     package "dns-tsig";
-    package "nocrypto" ;
     package ~min:"2.0.0" "irmin-mirage";
     package ~min:"2.0.0" "irmin-mirage-git";
     package "conduit-mirage";
   ] in
   foreign
-    ~deps:[abstract nocrypto]
     ~keys:[Key.abstract remote_k ; Key.abstract axfr]
     ~packages
     "Unikernel.Main"

--- a/primary-with-zone/config.ml
+++ b/primary-with-zone/config.ml
@@ -10,12 +10,10 @@ let dns_handler =
       package "logs" ;
       package ~sublibs:[ "zone" ; "mirage" ] "dns-server";
       package "dns-tsig";
-      package "nocrypto";
       package ~min:"2.0.0" "mirage-kv";
     ]
   in
   foreign
-    ~deps:[abstract nocrypto]
     ~packages
     "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4 @-> kv_ro @-> job)

--- a/primary-with-zone/unikernel.ml
+++ b/primary-with-zone/unikernel.ml
@@ -5,7 +5,7 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
 
   module D = Dns_server_mirage.Make(P)(M)(T)(S)
 
-  let start _rng _pclock _mclock _ s kv _ =
+  let start _rng _pclock _mclock _ s kv =
     KV.get kv (Mirage_kv.Key.v "zone") >>= function
     | Error e ->
       Logs.err (fun m -> m "couldn't get zone file %a" KV.pp_error e) ; exit 64

--- a/primary/config.ml
+++ b/primary/config.ml
@@ -12,12 +12,10 @@ let dns_handler =
       package "logs" ;
       package ~min:"4.3.0" ~sublibs:[ "mirage" ] "dns-server";
       package "dns-tsig";
-      package "nocrypto"
     ]
   in
   foreign
     ~keys:[Key.abstract axfr]
-    ~deps:[abstract nocrypto]
     ~packages
     "Unikernel.Main"
     (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)

--- a/primary/unikernel.ml
+++ b/primary/unikernel.ml
@@ -53,7 +53,7 @@ module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MC
     let t = insert (ptr_name "7") Ptr (ttl, h "certificate") t in
     t
 
-  let start _rng _pclock _mclock _ s _ =
+  let start _rng _pclock _mclock _ s =
     let trie = data in
     (match Dns_trie.check trie with
      | Ok () -> ()

--- a/resolver/config.ml
+++ b/resolver/config.ml
@@ -11,7 +11,6 @@ let dns_handler =
     ]
   in
   foreign
-    ~deps:[abstract nocrypto]
     ~packages
     "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)
 

--- a/resolver/unikernel.ml
+++ b/resolver/unikernel.ml
@@ -2,7 +2,7 @@
 module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) = struct
   module D = Dns_resolver_mirage.Make(R)(P)(M)(T)(S)
 
-  let start _r _pclock _mclock _ s _ =
+  let start _r _pclock _mclock _ s =
     let now = M.elapsed_ns () in
     let server =
       Dns_server.Primary.create ~rng:R.generate Dns_resolver_root.reserved

--- a/secondary/config.ml
+++ b/secondary/config.ml
@@ -12,12 +12,10 @@ let dns_handler =
       package "logs" ;
       package ~min:"4.3.0" ~sublibs:["mirage"] "dns-server";
       package "dns-tsig";
-      package "nocrypto";
     ]
   and keys = Key.([ abstract keys ])
   in
   foreign
-    ~deps:[abstract nocrypto]
     ~keys
     ~packages
     "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)

--- a/secondary/unikernel.ml
+++ b/secondary/unikernel.ml
@@ -2,7 +2,7 @@
 module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) = struct
   module D = Dns_server_mirage.Make(P)(M)(T)(S)
 
-  let start _rng _pclock _mclock _ s _ =
+  let start _rng _pclock _mclock _ s =
     let keys = List.fold_left (fun acc str ->
         match Dns.Dnskey.name_key_of_string str with
         | Error (`Msg msg) -> Logs.err (fun m -> m "key parse error %s" msg) ; exit 64

--- a/stub-resolver/config.ml
+++ b/stub-resolver/config.ml
@@ -15,7 +15,6 @@ let dns_handler =
     ]
   in
   foreign
-    ~deps:[abstract nocrypto]
     ~keys:[Key.abstract resolver]
     ~packages
     "Unikernel.Main" (random @-> pclock @-> mclock @-> time @-> stackv4 @-> job)

--- a/stub-resolver/unikernel.ml
+++ b/stub-resolver/unikernel.ml
@@ -2,7 +2,7 @@
 module Main (R : Mirage_random.S) (P : Mirage_clock.PCLOCK) (M : Mirage_clock.MCLOCK) (T : Mirage_time.S) (S : Mirage_stack.V4) = struct
   module D = Dns_resolver_mirage.Make(R)(P)(M)(T)(S)
 
-  let start _r _pclock _mclock _ s _ =
+  let start _r _pclock _mclock _ s =
     let trie =
       let name = Domain_name.of_string_exn "resolver"
       and ip = Key_gen.resolver ()

--- a/tlstunnel/config.ml
+++ b/tlstunnel/config.ml
@@ -18,9 +18,8 @@ let certs = generic_kv_ro "tls"
 
 let main =
   foreign
-    ~deps:[ abstract nocrypto ]
     ~keys:[ Key.abstract backend_ip ; Key.abstract backend_port ; Key.abstract frontend_port ]
-    ~packages:[ package ~sublibs:["mirage"] "tls" ]
+    ~packages:[ package "tls-mirage" ]
     "Unikernel.Main"
     (kv_ro @-> pclock @-> stackv4 @-> stackv4 @-> job)
 

--- a/tlstunnel/unikernel.ml
+++ b/tlstunnel/unikernel.ml
@@ -64,7 +64,7 @@ module Main (Keys : Mirage_kv.RO) (Pclock : Mirage_clock.PCLOCK) (Public : Mirag
     X509.certificate kv `Default >|= fun cert ->
     Tls.Config.server ~certificates:(`Single cert) ()
 
-  let start kv _ pub priv _ =
+  let start kv _ pub priv =
     let frontend_port = Key_gen.frontend_port () in
     tls_init kv >>= fun config ->
     let priv_tcp = Private.tcpv4 priv in

--- a/unikernels.opam
+++ b/unikernels.opam
@@ -9,7 +9,7 @@ license: "public domain"
 
 depends: [
   "lwt"
-  "mirage" {>= "3.7.1"}
+  "mirage" {>= "3.7.5"}
   "ocaml" {>= "4.07.0"}
 ]
 


### PR DESCRIPTION
i.e. https://github.com/mirage/ocaml-dns/pull/219